### PR TITLE
feat: simplify importCss & trans arrow func import

### DIFF
--- a/packages/asyncmodule-import/demo/asyncImport.js
+++ b/packages/asyncmodule-import/demo/asyncImport.js
@@ -3,9 +3,14 @@ const AsyncComponent = AsyncModule({
     delay: 300
 });
 const Home = AsyncComponent(import('./views/home'));
+const Side = AsyncComponent(import('./views/side'));
 
 import rand_AsyncModule from 'react-asyncmodule';
 const rand_Component = rand_AsyncModule({
     delay: 300
+});
+
+export const A = AsyncImport({
+    load: ()=>import('./a')
 });
 const Homex = rand_Component(import(/*webpackChunkName: "arandomname"*/'./views/homex'));

--- a/packages/asyncmodule-import/package.json
+++ b/packages/asyncmodule-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-asyncmodule-import",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/asyncmodule-import/test/cases/arrowCall.js
+++ b/packages/asyncmodule-import/test/cases/arrowCall.js
@@ -1,0 +1,5 @@
+export const A = AsyncImport({
+    load: ()=>import('./a'),
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/arrowCall_res.js
+++ b/packages/asyncmodule-import/test/cases/arrowCall_res.js
@@ -1,0 +1,9 @@
+export const A = AsyncImport({
+    load: () => ({
+        load: () => Promise.all([import( /*webpackChunkName: "a"*/'./a')]).then(jsprim => jsprim[0]),
+        resolveWeak: () => require.resolveWeak('./a'),
+        chunk: () => 'a'
+    }),
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/simplifyImportCss.js
+++ b/packages/asyncmodule-import/test/cases/simplifyImportCss.js
@@ -1,0 +1,3 @@
+const Home = AsyncComponent(import('./views/home'));
+const Side = AsyncComponent(import('./views/side'));
+const Footer = AsyncComponent(import('./views/footer'));

--- a/packages/asyncmodule-import/test/cases/simplifyImportCss_res.js
+++ b/packages/asyncmodule-import/test/cases/simplifyImportCss_res.js
@@ -1,0 +1,16 @@
+import ImportCss from 'react-asyncmodule-tool/dist/importcss';
+const Home = AsyncComponent({
+  load: () => Promise.all([import( /*webpackChunkName: "home"*/'./views/home'), ImportCss('home')]).then(jsprim => jsprim[0]),
+  resolveWeak: () => require.resolveWeak('./views/home'),
+  chunk: () => 'home'
+});
+const Side = AsyncComponent({
+  load: () => Promise.all([import( /*webpackChunkName: "side"*/'./views/side'), ImportCss('side')]).then(jsprim => jsprim[0]),
+  resolveWeak: () => require.resolveWeak('./views/side'),
+  chunk: () => 'side'
+});
+const Footer = AsyncComponent({
+  load: () => Promise.all([import( /*webpackChunkName: "footer"*/'./views/footer'), ImportCss('footer')]).then(jsprim => jsprim[0]),
+  resolveWeak: () => require.resolveWeak('./views/footer'),
+  chunk: () => 'footer'
+});

--- a/packages/asyncmodule-import/test/test.js
+++ b/packages/asyncmodule-import/test/test.js
@@ -3,21 +3,21 @@ import asyncModuleImport from '../src/index';
 var babel = require("babel-core");
 
 describe('asyncmodule import', () => {
-    test('rename names import', () => {
+    test('rename', () => {
         const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/rename.js'), {
             plugins: ['syntax-dynamic-import', asyncModuleImport]
         });
         const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/rename_res.js'));
         expect(srcCode).toBe(expectCode);
     });
-    test('rename names import', () => {
+    test('common', () => {
         const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/common.js'), {
             plugins: ['syntax-dynamic-import', asyncModuleImport]
         });
         const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/common_res.js'));
         expect(srcCode).toBe(expectCode);
     });
-    test('rename names import', () => {
+    test('importCss', () => {
         const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/importCss.js'), {
             plugins: ['syntax-dynamic-import',[asyncModuleImport, {
                 importCss: true
@@ -26,11 +26,27 @@ describe('asyncmodule import', () => {
         const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/importCss_res.js'));
         expect(srcCode).toBe(expectCode);
     });
-    test('rename names import', () => {
+    test('defaultcomment', () => {
         const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/defaultcomment.js'), {
             plugins: ['syntax-dynamic-import', asyncModuleImport]
         });
         const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/defaultcomment_res.js'));
+        expect(srcCode).toBe(expectCode);
+    });
+    test('arrowCall', () => {
+        const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/arrowCall.js'), {
+            plugins: ['syntax-dynamic-import', asyncModuleImport]
+        });
+        const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/arrowCall_res.js'));
+        expect(srcCode).toBe(expectCode);
+    });
+    test('simplifyImportCss', () => {
+        const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/simplifyImportCss.js'), {
+            plugins: ['syntax-dynamic-import', [asyncModuleImport, {
+                importCss: true
+            }]]
+        });
+        const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/simplifyImportCss_res.js'));
         expect(srcCode).toBe(expectCode);
     });
 });


### PR DESCRIPTION
- [x] 1. 简化ImportCss
- [x] 2. import在箭头函数中调用转码
- [x] 3. 增加单测