### PR TITLE
Feature/simplify import css

### DIFF
--- a/packages/asyncmodule-import/README.md
+++ b/packages/asyncmodule-import/README.md
@@ -80,5 +80,67 @@ const Home = AsyncComponent({
 });
 ```
 
+```javascript
+// when importCss set default false
+import AsyncModule from 'react-asyncmodule';
+const AsyncComponent = AsyncModule({
+    delay: 300,
+    ...
+});
+// arrow function
+const A = AsyncModule({
+    load: () => import('./a'),
+    loading: 'LoadingView',
+    error: 'ErrorView',
+});
+// arrow function in blockstament
+const B = AsyncModule({
+    load: () => {
+        return import('./b');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView',
+});
+// es6 object method
+const C = AsyncModule({
+    load() {
+        return import('./c');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView',
+});
+
+ ↓ ↓ ↓ ↓ ↓ ↓
+ 
+import AsyncModule from 'react-asyncmodule';
+const AsyncComponent = AsyncModule({
+    delay: 300,
+    ...
+});
+
+const A = AsyncModule({
+    load: () => Promise.all([import( /*webpackChunkName: "a"*/'./a')]).then(jsprim => jsprim[0]),
+    resolveWeak: () => require.resolveWeak('./a'),
+    chunk: () => 'a',
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});
+
+const B = AsyncModule({
+    load: () => Promise.all([import( /*webpackChunkName: "b"*/'./b')]).then(jsprim => jsprim[0]),
+    resolveWeak: () => require.resolveWeak('./b'),
+    chunk: () => 'b',
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});
+
+const C = AsyncModule({
+    load: () => Promise.all([import( /*webpackChunkName: "c"*/'./c')]).then(jsprim => jsprim[0]),
+    resolveWeak: () => require.resolveWeak('./c'),
+    chunk: () => 'c',
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});
+```
 
 > Css split can be implemented by [extract-css-chunks-webpack-plugin](https://github.com/faceyspacey/extract-css-chunks-webpack-plugin)

--- a/packages/asyncmodule-import/demo/asyncImport.js
+++ b/packages/asyncmodule-import/demo/asyncImport.js
@@ -12,6 +12,25 @@ const rand_Component = rand_AsyncModule({
 });
 
 export const A = AsyncImport({
-    load: ()=>import('./a')
+    load: () => {
+        import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView',
 });
+
+export const B = AsyncImport({
+    load: () => import('./a'),
+    loading: 'LoadingView',
+    error: 'ErrorView',
+});
+
+export const C = AsyncImport({
+    load() {
+        import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView',
+});
+
 const Homex = rand_Component(import(/*webpackChunkName: "arandomname"*/'./views/homex'));

--- a/packages/asyncmodule-import/demo/asyncImport.js
+++ b/packages/asyncmodule-import/demo/asyncImport.js
@@ -11,23 +11,39 @@ const rand_Component = rand_AsyncModule({
     delay: 300
 });
 
-export const B = AsyncImport({
+export const A = AsyncImport({
     load: () => import('./a'),
     loading: 'LoadingView',
     error: 'ErrorView',
 });
 
-export const C = AsyncImport({
-    load() {
+export const B = AsyncImport({
+    load: () => {
+        return import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView',
+});
+export const Bx = AsyncImport({
+    load: () => {
         import('./a');
     },
     loading: 'LoadingView',
     error: 'ErrorView',
 });
 
-export const D = AsyncImport({
+
+export const C = AsyncImport({
     load() {
         return import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView',
+});
+
+export const Cx = AsyncImport({
+    load() {
+        import('./a');
     },
     loading: 'LoadingView',
     error: 'ErrorView',

--- a/packages/asyncmodule-import/demo/asyncImport.js
+++ b/packages/asyncmodule-import/demo/asyncImport.js
@@ -11,14 +11,6 @@ const rand_Component = rand_AsyncModule({
     delay: 300
 });
 
-export const A = AsyncImport({
-    load: () => {
-        import('./a');
-    },
-    loading: 'LoadingView',
-    error: 'ErrorView',
-});
-
 export const B = AsyncImport({
     load: () => import('./a'),
     loading: 'LoadingView',
@@ -28,6 +20,14 @@ export const B = AsyncImport({
 export const C = AsyncImport({
     load() {
         import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView',
+});
+
+export const D = AsyncImport({
+    load() {
+        return import('./a');
     },
     loading: 'LoadingView',
     error: 'ErrorView',

--- a/packages/asyncmodule-import/dist/index.js
+++ b/packages/asyncmodule-import/dist/index.js
@@ -73,7 +73,7 @@ exports.default = function (_ref) {
             importPath = returnImport ? path.get('value.body') : path.get('value.body.body.0.expression');
         }
         if (nodeType === 'ObjectMethod') {
-            importPath = path.get('body.body.0.expression');
+            importPath = returnImport ? path.get('body.body.0.argument') : path.get('body.body.0.expression');
         }
 
         var _importPath$node$argu = _slicedToArray(importPath.node.arguments, 1);
@@ -150,8 +150,18 @@ exports.default = function (_ref) {
                 var node = path.node;
 
                 var importCss = opts && opts.importCss || false;
-                if (node.key.name === 'load' && node.body.body && t.isImport(node.body.body[0].expression.callee)) {
-                    astParser(path, importCss);
+                var returnImport = undefined;
+                if (node.key.name === 'load' && t.isBlockStatement(node.body)) {
+                    if (t.isExpressionStatement(node.body.body[0]) && t.isImport(node.body.body[0].expression.callee)) {
+                        returnImport = false;
+                    } else if (t.isReturnStatement(node.body.body[0]) && t.isImport(node.body.body[0].argument.callee)) {
+                        returnImport = true;
+                    } else {
+                        return;
+                    }
+                    astParser(path, importCss, returnImport);
+                } else {
+                    return;
                 }
             }
         }

--- a/packages/asyncmodule-import/dist/index.js
+++ b/packages/asyncmodule-import/dist/index.js
@@ -70,10 +70,10 @@ exports.default = function (_ref) {
             importPath = path.get('arguments.0');
         }
         if (nodeType === 'ObjectProperty') {
-            importPath = returnImport ? path.get('value.body') : path.get('value.body.body.0.expression');
+            importPath = !returnImport ? path.get('value.body') : path.get('value.body.body.0.argument');
         }
         if (nodeType === 'ObjectMethod') {
-            importPath = returnImport ? path.get('body.body.0.argument') : path.get('body.body.0.expression');
+            importPath = path.get('body.body.0.argument');
         }
 
         var _importPath$node$argu = _slicedToArray(importPath.node.arguments, 1);
@@ -135,14 +135,16 @@ exports.default = function (_ref) {
                 var importCss = opts && opts.importCss || false;
                 var returnImport = undefined;
                 if (node.key.name === 'load' && t.isArrowFunctionExpression(node.value)) {
-                    if (node.value.body && t.isImport(node.value.body.callee)) {
-                        returnImport = true;
-                    } else if (node.value.body.body && t.isImport(node.value.body.body[0].expression.callee)) {
+                    if (node.value.body && t.isCallExpression(node.value.body) && t.isImport(node.value.body.callee)) {
                         returnImport = false;
+                    } else if (node.value.body && t.isBlockStatement(node.value.body) && t.isReturnStatement(node.value.body.body[0]) && t.isCallExpression(node.value.body.body[0].argument) && t.isImport(node.value.body.body[0].argument.callee)) {
+                        returnImport = true;
                     }
                     if (returnImport !== undefined) {
                         astParser(path, importCss, returnImport);
                     }
+                } else {
+                    return;
                 }
             },
             ObjectMethod: function ObjectMethod(path, _ref4) {
@@ -150,16 +152,8 @@ exports.default = function (_ref) {
                 var node = path.node;
 
                 var importCss = opts && opts.importCss || false;
-                var returnImport = undefined;
-                if (node.key.name === 'load' && t.isBlockStatement(node.body)) {
-                    if (t.isExpressionStatement(node.body.body[0]) && t.isImport(node.body.body[0].expression.callee)) {
-                        returnImport = false;
-                    } else if (t.isReturnStatement(node.body.body[0]) && t.isImport(node.body.body[0].argument.callee)) {
-                        returnImport = true;
-                    } else {
-                        return;
-                    }
-                    astParser(path, importCss, returnImport);
+                if (node.key.name === 'load' && t.isBlockStatement(node.body) && t.isReturnStatement(node.body.body[0]) && t.isCallExpression(node.body.body[0].argument) && t.isImport(node.body.body[0].argument.callee)) {
+                    astParser(path, importCss);
                 } else {
                     return;
                 }

--- a/packages/asyncmodule-import/package.json
+++ b/packages/asyncmodule-import/package.json
@@ -1,7 +1,7 @@
 {
   "name": "babel-plugin-asyncmodule-import",
-  "version": "0.1.9",
-  "description": "",
+  "version": "0.2.0",
+  "description": "A babel plugin",
   "main": "dist/index.js",
   "scripts": {
     "dev": "BABEL_ENV=commonjs babel-node demo/run.js --require babel-core/register",

--- a/packages/asyncmodule-import/package.json
+++ b/packages/asyncmodule-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-asyncmodule-import",
-  "version": "0.1.5",
+  "version": "0.1.9-beta.1",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/asyncmodule-import/package.json
+++ b/packages/asyncmodule-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-asyncmodule-import",
-  "version": "0.1.9-beta.1",
+  "version": "0.1.9",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/asyncmodule-import/src/index.js
+++ b/packages/asyncmodule-import/src/index.js
@@ -1,7 +1,5 @@
 export default function(_ref) {
     let t = _ref.types;
-    let asyncModule = 'asyncModule',
-        asyncComponent = 'asyncComponent';
 
     const addComments = module => {
         const modulePath = module.value;
@@ -18,7 +16,7 @@ export default function(_ref) {
         };
     };
 
-    const buildLoad = (importPath, moduleName, importCss = false) => {
+    const buildLoad = (importPath, moduleName, importCss) => {
         let loadMaterials = [importPath.node];
 
         if (importCss) {
@@ -76,25 +74,28 @@ export default function(_ref) {
                 [t.importDefaultSpecifier(t.identifier('ImportCss'))],
                 t.stringLiteral('react-asyncmodule-tool/dist/importcss')
             );
-            const programPath = getProgramPath(path)
-            const fstLn = programPath.node.body[0];
-            const existedImportCss = t.isImportDeclaration(fstLn) && fstLn.specifiers.length && fstLn.specifiers[0].local.name === fstLn.specifiers[0].local.name === 'ImportCss'
-            if (!existedImportCss) {
+            const programPath = getProgramPath(path);
+            if (!programPath.scope.existedImportCss) {
                 programPath.unshiftContainer('body', declaration);
+                programPath.scope.existedImportCss = true;
             }
         }
     }
-    const astParser = (path, importCss) => {
+
+    const astParser = (path, importCss, returnImport=undefined) => {
         handleImportCss(path, importCss);
         // add leadingComments to the import argument module
-        const {type: nodeType} = path.node;
+        const { type: nodeType } = path.node;
         let importPath = '';
         let module='';
         if (nodeType === 'CallExpression') {
             importPath = path.get('arguments.0');
         }
-        if (nodeType === 'ArrowFunctionExpression') {
-            importPath = path.get('body');
+        if (nodeType === 'ObjectProperty') {
+            importPath = returnImport ? path.get('value.body') : path.get('value.body.body.0.expression');
+        }
+        if (nodeType === 'ObjectMethod') {
+            importPath = path.get('body.body.0.expression');
         }
         [module] = importPath.node.arguments;
         const { modulePath, moduleName } = addComments(module);
@@ -103,30 +104,66 @@ export default function(_ref) {
         const resolveWeak = buildResolveWeak(modulePath);
         const chunkNameCmt = module.leadingComments.find(cmt=>(cmt.value.includes('webpackChunkName')));
         const chunk = buildChunkName(chunkNameCmt);
-
-        importPath.replaceWith(t.objectExpression([load, resolveWeak, chunk]));
+        if (nodeType === 'CallExpression') {
+            importPath.replaceWith(t.objectExpression([load, resolveWeak, chunk]));
+        }
+        if (nodeType === 'ObjectProperty') {
+            const more = path.parent.properties.splice(1);
+            const nmore = more.map((property,index)=>{
+                return t.objectProperty(property.key, property.value)
+            });
+            path.replaceWithMultiple([load, resolveWeak, chunk].concat(nmore));
+        }
+        if (nodeType === 'ObjectMethod') {
+            const more = path.parent.properties.splice(1);
+            const nmore = more.map((property,index)=>{
+                return t.objectProperty(property.key, property.value)
+            });
+            path.replaceWithMultiple([load, resolveWeak, chunk].concat(nmore));
+        }
     }
     return {
         visitor: {
+            ImportDeclaration(path) {
+                const { node } = path;
+                const programPath = getProgramPath(path);
+                if (node.specifiers.length && node.specifiers[0].local.name === 'ImportCss') {
+                    programPath.scope.existedImportCss = true;
+                }
+            },
             CallExpression(path, {
-                opts = {}
+                opts
             }) {
                 const { node } = path;
-                const { importCss } = opts;
-                if (!node) return;
+                const importCss = opts && opts.importCss || false;
 
                 if (t.isCallExpression(node.arguments[0]) && t.isImport(node.arguments[0].callee)) {
                     astParser(path, importCss);
                 }
             },
-            ArrowFunctionExpression(path, {
-                opts={}
+            ObjectProperty(path, {
+                opts
             }) {
                 const { node } = path;
-                const { importCss } = opts;
-                if (!node) return;
-
-                if (t.isCallExpression(node.body) && t.isImport(node.body.callee)) {
+                const importCss = opts && opts.importCss || false;
+                let returnImport = undefined;
+                if (node.key.name === 'load' && t.isArrowFunctionExpression(node.value)) {
+                    if (node.value.body && t.isImport(node.value.body.callee)) {
+                        returnImport = true;
+                    } else if (node.value.body.body && t.isImport(node.value.body.body[0].expression.callee)) {
+                        returnImport = false;
+                    }
+                    if (returnImport !== undefined) {
+                        astParser(path, importCss, returnImport);
+                    }
+                }
+            },
+            ObjectMethod(path, {
+                opts
+            }) {
+                const { node } = path;
+                const importCss = opts && opts.importCss || false;
+                if (node.key.name === 'load' && node.body.body && t.isImport(node.body.body[0].expression.callee)) {
                     astParser(path, importCss);
                 }
             }

--- a/packages/asyncmodule-import/src/index.js
+++ b/packages/asyncmodule-import/src/index.js
@@ -92,10 +92,10 @@ export default function(_ref) {
             importPath = path.get('arguments.0');
         }
         if (nodeType === 'ObjectProperty') {
-            importPath = returnImport ? path.get('value.body') : path.get('value.body.body.0.expression');
+            importPath = !returnImport ? path.get('value.body') : path.get('value.body.body.0.argument');
         }
         if (nodeType === 'ObjectMethod') {
-            importPath = returnImport ? path.get('body.body.0.argument'): path.get('body.body.0.expression');
+            importPath = path.get('body.body.0.argument');
         }
         [module] = importPath.node.arguments;
         const { modulePath, moduleName } = addComments(module);
@@ -131,9 +131,7 @@ export default function(_ref) {
                     programPath.scope.existedImportCss = true;
                 }
             },
-            CallExpression(path, {
-                opts
-            }) {
+            CallExpression(path, { opts }) {
                 const { node } = path;
                 const importCss = opts && opts.importCss || false;
 
@@ -141,38 +139,28 @@ export default function(_ref) {
                     astParser(path, importCss);
                 }
             },
-            ObjectProperty(path, {
-                opts
-            }) {
+            ObjectProperty(path, { opts }) {
                 const { node } = path;
                 const importCss = opts && opts.importCss || false;
                 let returnImport = undefined;
                 if (node.key.name === 'load' && t.isArrowFunctionExpression(node.value)) {
-                    if (node.value.body && t.isImport(node.value.body.callee)) {
-                        returnImport = true;
-                    } else if (node.value.body.body && t.isImport(node.value.body.body[0].expression.callee)) {
+                    if (node.value.body && t.isCallExpression(node.value.body) && t.isImport(node.value.body.callee)) {
                         returnImport = false;
+                    } else if (node.value.body&& t.isBlockStatement(node.value.body) && t.isReturnStatement(node.value.body.body[0]) && t.isCallExpression(node.value.body.body[0].argument) && t.isImport(node.value.body.body[0].argument.callee)) {
+                        returnImport = true;
                     }
                     if (returnImport !== undefined) {
                         astParser(path, importCss, returnImport);
                     }
+                } else {
+                    return;
                 }
             },
-            ObjectMethod(path, {
-                opts
-            }) {
+            ObjectMethod(path, { opts }) {
                 const { node } = path;
                 const importCss = opts && opts.importCss || false;
-                let returnImport = undefined;
-                if (node.key.name === 'load' &&  t.isBlockStatement(node.body)) {
-                    if (t.isExpressionStatement(node.body.body[0]) && t.isImport(node.body.body[0].expression.callee)) {
-                        returnImport = false;
-                    } else if (t.isReturnStatement(node.body.body[0]) && t.isImport(node.body.body[0].argument.callee)) {
-                        returnImport = true;
-                    } else {
-                        return;
-                    }
-                    astParser(path, importCss, returnImport);
+                if (node.key.name === 'load' &&  t.isBlockStatement(node.body) && t.isReturnStatement(node.body.body[0]) && t.isCallExpression(node.body.body[0].argument) && t.isImport(node.body.body[0].argument.callee)) {
+                    astParser(path, importCss);
                 } else {
                     return;
                 }

--- a/packages/asyncmodule-import/test/cases/arrowCall.js
+++ b/packages/asyncmodule-import/test/cases/arrowCall.js
@@ -3,3 +3,10 @@ export const A = AsyncImport({
     loading: 'LoadingView',
     error: 'ErrorView'
 });
+export const B = AsyncImport({
+    load: ()=> {
+        import('./b')
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/arrowCall.js
+++ b/packages/asyncmodule-import/test/cases/arrowCall.js
@@ -1,11 +1,11 @@
 export const A = AsyncImport({
-    load: ()=>import('./a'),
+    load: () => import('./a'),
     loading: 'LoadingView',
     error: 'ErrorView'
 });
 export const B = AsyncImport({
-    load: ()=> {
-        import('./b')
+    load: () => {
+        return import('./b')
     },
     loading: 'LoadingView',
     error: 'ErrorView'

--- a/packages/asyncmodule-import/test/cases/arrowCall_res.js
+++ b/packages/asyncmodule-import/test/cases/arrowCall_res.js
@@ -1,9 +1,14 @@
 export const A = AsyncImport({
-    load: () => ({
-        load: () => Promise.all([import( /*webpackChunkName: "a"*/'./a')]).then(jsprim => jsprim[0]),
-        resolveWeak: () => require.resolveWeak('./a'),
-        chunk: () => 'a'
-    }),
+    load: () => Promise.all([import( /*webpackChunkName: "a"*/'./a')]).then(jsprim => jsprim[0]),
+    resolveWeak: () => require.resolveWeak('./a'),
+    chunk: () => 'a',
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});
+export const B = AsyncImport({
+    load: () => Promise.all([import( /*webpackChunkName: "b"*/'./b')]).then(jsprim => jsprim[0]),
+    resolveWeak: () => require.resolveWeak('./b'),
+    chunk: () => 'b',
     loading: 'LoadingView',
     error: 'ErrorView'
 });

--- a/packages/asyncmodule-import/test/cases/empty.js
+++ b/packages/asyncmodule-import/test/cases/empty.js
@@ -3,3 +3,18 @@ const AsyncComponent = AsyncModule({
     delay: 300
 });
 const Home = import('a');
+export const A = AsyncImport({
+    loadx() {
+        import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});
+export const B = AsyncImport({
+    load() {
+        const c = 1;
+        import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/empty.js
+++ b/packages/asyncmodule-import/test/cases/empty.js
@@ -1,0 +1,5 @@
+import AsyncModule from 'react-asyncmodule'; 
+const AsyncComponent = AsyncModule({
+    delay: 300
+});
+const Home = import('a');

--- a/packages/asyncmodule-import/test/cases/empty_res.js
+++ b/packages/asyncmodule-import/test/cases/empty_res.js
@@ -3,3 +3,18 @@ const AsyncComponent = AsyncModule({
     delay: 300
 });
 const Home = import('a');
+export const A = AsyncImport({
+    loadx() {
+        import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});
+export const B = AsyncImport({
+    load() {
+        const c = 1;
+        import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/empty_res.js
+++ b/packages/asyncmodule-import/test/cases/empty_res.js
@@ -1,0 +1,5 @@
+import AsyncModule from 'react-asyncmodule'; 
+const AsyncComponent = AsyncModule({
+    delay: 300
+});
+const Home = import('a');

--- a/packages/asyncmodule-import/test/cases/objectMethod.js
+++ b/packages/asyncmodule-import/test/cases/objectMethod.js
@@ -5,3 +5,10 @@ export const A = AsyncImport({
     loading: 'LoadingView',
     error: 'ErrorView'
 });
+export const B = AsyncImport({
+    load() {
+        return import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/objectMethod.js
+++ b/packages/asyncmodule-import/test/cases/objectMethod.js
@@ -1,12 +1,5 @@
 export const A = AsyncImport({
     load() {
-        import('./a');
-    },
-    loading: 'LoadingView',
-    error: 'ErrorView'
-});
-export const B = AsyncImport({
-    load() {
         return import('./a');
     },
     loading: 'LoadingView',

--- a/packages/asyncmodule-import/test/cases/objectMethod.js
+++ b/packages/asyncmodule-import/test/cases/objectMethod.js
@@ -1,0 +1,7 @@
+export const A = AsyncImport({
+    load() {
+        import('./a');
+    },
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/objectMethod_res.js
+++ b/packages/asyncmodule-import/test/cases/objectMethod_res.js
@@ -5,3 +5,10 @@ export const A = AsyncImport({
     loading: 'LoadingView',
     error: 'ErrorView'
 });
+export const B = AsyncImport({
+    load: () => Promise.all([import( /*webpackChunkName: "a"*/'./a')]).then(jsprim => jsprim[0]),
+    resolveWeak: () => require.resolveWeak('./a'),
+    chunk: () => 'a',
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/objectMethod_res.js
+++ b/packages/asyncmodule-import/test/cases/objectMethod_res.js
@@ -5,10 +5,3 @@ export const A = AsyncImport({
     loading: 'LoadingView',
     error: 'ErrorView'
 });
-export const B = AsyncImport({
-    load: () => Promise.all([import( /*webpackChunkName: "a"*/'./a')]).then(jsprim => jsprim[0]),
-    resolveWeak: () => require.resolveWeak('./a'),
-    chunk: () => 'a',
-    loading: 'LoadingView',
-    error: 'ErrorView'
-});

--- a/packages/asyncmodule-import/test/cases/objectMethod_res.js
+++ b/packages/asyncmodule-import/test/cases/objectMethod_res.js
@@ -1,0 +1,7 @@
+export const A = AsyncImport({
+    load: () => Promise.all([import( /*webpackChunkName: "a"*/'./a')]).then(jsprim => jsprim[0]),
+    resolveWeak: () => require.resolveWeak('./a'),
+    chunk: () => 'a',
+    loading: 'LoadingView',
+    error: 'ErrorView'
+});

--- a/packages/asyncmodule-import/test/cases/simplifyImportCss.js
+++ b/packages/asyncmodule-import/test/cases/simplifyImportCss.js
@@ -1,3 +1,4 @@
+import AsyncModule from 'react-asyncmodule'; 
 const Home = AsyncComponent(import('./views/home'));
 const Side = AsyncComponent(import('./views/side'));
 const Footer = AsyncComponent(import('./views/footer'));

--- a/packages/asyncmodule-import/test/cases/simplifyImportCss_res.js
+++ b/packages/asyncmodule-import/test/cases/simplifyImportCss_res.js
@@ -1,4 +1,5 @@
 import ImportCss from 'react-asyncmodule-tool/dist/importcss';
+import AsyncModule from 'react-asyncmodule'; 
 const Home = AsyncComponent({
   load: () => Promise.all([import( /*webpackChunkName: "home"*/'./views/home'), ImportCss('home')]).then(jsprim => jsprim[0]),
   resolveWeak: () => require.resolveWeak('./views/home'),

--- a/packages/asyncmodule-import/test/cases/somepackage.js
+++ b/packages/asyncmodule-import/test/cases/somepackage.js
@@ -1,5 +1,0 @@
-import AsyncModule from 'somepack';
-const AsyncComponent = AsyncModule({
-    delay: 300
-});
-const Home = AsyncComponent(import('./views/home'));

--- a/packages/asyncmodule-import/test/cases/somepackage_res.js
+++ b/packages/asyncmodule-import/test/cases/somepackage_res.js
@@ -1,5 +1,0 @@
-import AsyncModule from 'somepack';
-const AsyncComponent = AsyncModule({
-    delay: 300
-});
-const Home = AsyncComponent(import('./views/home'));

--- a/packages/asyncmodule-import/test/test.js
+++ b/packages/asyncmodule-import/test/test.js
@@ -2,22 +2,23 @@ import path from 'path';
 import asyncModuleImport from '../src/index';
 var babel = require("babel-core");
 
-describe('asyncmodule import', () => {
-    test('rename', () => {
+describe('asyncmodule import', function() {
+    
+    test('rename', function()  {
         const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/rename.js'), {
             plugins: ['syntax-dynamic-import', asyncModuleImport]
         });
         const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/rename_res.js'));
         expect(srcCode).toBe(expectCode);
     });
-    test('common', () => {
+    test('common', function() {
         const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/common.js'), {
             plugins: ['syntax-dynamic-import', asyncModuleImport]
         });
         const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/common_res.js'));
         expect(srcCode).toBe(expectCode);
     });
-    test('importCss', () => {
+    test('importCss', function() {
         const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/importCss.js'), {
             plugins: ['syntax-dynamic-import',[asyncModuleImport, {
                 importCss: true
@@ -26,27 +27,41 @@ describe('asyncmodule import', () => {
         const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/importCss_res.js'));
         expect(srcCode).toBe(expectCode);
     });
-    test('defaultcomment', () => {
-        const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/defaultcomment.js'), {
-            plugins: ['syntax-dynamic-import', asyncModuleImport]
-        });
-        const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/defaultcomment_res.js'));
-        expect(srcCode).toBe(expectCode);
-    });
-    test('arrowCall', () => {
-        const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/arrowCall.js'), {
-            plugins: ['syntax-dynamic-import', asyncModuleImport]
-        });
-        const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/arrowCall_res.js'));
-        expect(srcCode).toBe(expectCode);
-    });
-    test('simplifyImportCss', () => {
+    test('simplifyImportCss', function() {
         const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/simplifyImportCss.js'), {
             plugins: ['syntax-dynamic-import', [asyncModuleImport, {
                 importCss: true
             }]]
         });
         const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/simplifyImportCss_res.js'));
+        expect(srcCode).toBe(expectCode);
+    });
+    test('defaultcomment', function() {
+        const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/defaultcomment.js'), {
+            plugins: ['syntax-dynamic-import', asyncModuleImport]
+        });
+        const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/defaultcomment_res.js'));
+        expect(srcCode).toBe(expectCode);
+    });
+    test('arrowCall', function() {
+        const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/arrowCall.js'), {
+            plugins: ['syntax-dynamic-import', asyncModuleImport]
+        });
+        const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/arrowCall_res.js'));
+        expect(srcCode).toBe(expectCode);
+    });
+    test('epmty', function() {
+        const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/empty.js'), {
+            plugins: ['syntax-dynamic-import', asyncModuleImport]
+        });
+        const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/empty_res.js'));
+        expect(srcCode).toBe(expectCode);
+    });
+    test('objectMethodCall', function() {
+        const { code: srcCode } = babel.transformFileSync(path.join(__dirname, 'cases/objectMethod.js'), {
+            plugins: ['syntax-dynamic-import', asyncModuleImport]
+        });
+        const { code: expectCode } = babel.transformFileSync(path.join(__dirname, 'cases/objectMethod_res.js'));
         expect(srcCode).toBe(expectCode);
     });
 });


### PR DESCRIPTION
支持import()作为对象属性引用
特别支持3中形式
```javascript
//  1. 箭头函数
export const A = AsyncImport({
    load: () => import('./a'),
    loading: 'LoadingView',
    error: 'ErrorView',
});
 
// 2. 箭头函数内返回
export const B = AsyncImport({
    load: () => {
        return import('./a');
    },
    loading: 'LoadingView',
    error: 'ErrorView',
});
// 没返回不支持
export const Bx = AsyncImport({
    load: () => {
        import('./a');
    },
    loading: 'LoadingView',
    error: 'ErrorView',
});

// 3. es6对象方法
export const C = AsyncImport({
    load() {
        return import('./a');
    },
    loading: 'LoadingView',
    error: 'ErrorView',
});

// es6对象方法未返回不支持
export const Cx = AsyncImport({
    load() {
        import('./a');
    },
    loading: 'LoadingView',
    error: 'ErrorView',
});
```